### PR TITLE
Wrapped the DeskNoteTextView into a BScrollView (should fix #12)

### DIFF
--- a/DeskNoteTextView.cpp
+++ b/DeskNoteTextView.cpp
@@ -70,7 +70,7 @@ DeskNoteTextView::MouseDown(BPoint point)
 	GetMouse(&mousePoint, &mouseButtons, false);
 	if (mouseButtons != B_SECONDARY_MOUSE_BUTTON)
 		BTextView::MouseDown(point);
-	Parent()->MouseDown(point);
+	Parent()->Parent()->MouseDown(point);
 }
 
 

--- a/DeskNoteView.cpp
+++ b/DeskNoteView.cpp
@@ -59,7 +59,9 @@ DeskNoteView::DeskNoteView(BRect rect)
 		"\t\tIcon-O-Matic change the background\n\n"
 		"\tHave a nice day!"));
 	textView->SetText(defaultText);
-	AddChild(textView);
+	fScrollView = new BScrollView("DeskNoteScrollView", textView, B_FOLLOW_ALL,
+		0, false, true, B_NO_BORDER);
+	AddChild(fScrollView);
 
 	background = palette[0];
 	SetViewColor(background);

--- a/DeskNoteView.h
+++ b/DeskNoteView.h
@@ -80,6 +80,7 @@ private:
 	void 				_ShowContextMenu(BPoint where);
 	bool 				WeAreAReplicant;
 	DeskNoteTextView*	textView;
+	BScrollView*		fScrollView;
 	BRect 				ourSize;
 	BMenu*				colorMenu;
 	BMessage* 			orginalSettings;


### PR DESCRIPTION
-When resizing the view, the space obtained is now used to show any extra lines the note may have.
-When deleting lines, the view now scrolls back to the right place.

If one or two people can try this it would be great, seems to be working here.